### PR TITLE
fix(contents): user row id as key in Table

### DIFF
--- a/contents/Table/Cell.tsx
+++ b/contents/Table/Cell.tsx
@@ -273,7 +273,7 @@ export const TagsCell: FunctionComponent<TagsCellProps> = ({ column, dataRow }) 
   return (
     <StyledTdValue>
       {values.map((value: any) => (
-        <Tag>{value}</Tag>
+        <Tag key={String(value)}>{value}</Tag>
       ))}
     </StyledTdValue>
   )

--- a/contents/Table/Row.tsx
+++ b/contents/Table/Row.tsx
@@ -12,7 +12,7 @@ type RowProps = {
 export const Row: FunctionComponent<RowProps> = ({ columns, dataRow }) => (
   <tr>
     {columns.map(column => (
-      <Cell key={dataRow.id} column={column} dataRow={dataRow} />
+      <Cell key={`${dataRow.id}-${column.key}`} column={column} dataRow={dataRow} />
     ))}
   </tr>
 )

--- a/contents/Table/index.tsx
+++ b/contents/Table/index.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { SORT_ORDER } from '../../common/constants'
-import { generateKeyFromValue } from '../../helpers/generateKeyFromValue'
 import { Head } from './Head'
 import { getSortOrder, sort } from './helpers'
 import { LoadingCell } from './LoadingCell'
@@ -116,7 +115,7 @@ const TableWithRef: ForwardRefRenderFunction<HTMLTableElement, TableProps> = (
             {columns.map((column: TableColumnProps) => {
               const sortOrder = column.type !== 'action' && column.key === sortedKey ? sortedKeyOrder : undefined
 
-              return <Head key={column.label} column={column} onSort={sortDataByKey} sortOrder={sortOrder} />
+              return <Head key={column.key} column={column} onSort={sortDataByKey} sortOrder={sortOrder} />
             })}
           </tr>
         </thead>
@@ -135,7 +134,7 @@ const TableWithRef: ForwardRefRenderFunction<HTMLTableElement, TableProps> = (
 
           {!isLoading &&
             !isEmpty &&
-            visibleData.map(dataRow => <Row key={generateKeyFromValue(dataRow)} columns={columns} dataRow={dataRow} />)}
+            visibleData.map(dataRow => <Row key={dataRow.id} columns={columns} dataRow={dataRow} />)}
         </tbody>
       </table>
 

--- a/contents/Table/shapes.ts
+++ b/contents/Table/shapes.ts
@@ -8,6 +8,7 @@ export const ActionColumnPropType = BetterPropTypes.exact({
   accent: BetterPropTypes.oneOf(ACCENTS).isRequired,
   action: BetterPropTypes.func.isRequired,
   Icon: BetterPropTypes.elementType.isRequired,
+  key: BetterPropTypes.string.isRequired,
   label: BetterPropTypes.string.isRequired,
   type: BetterPropTypes.oneOf<'action'>(['action']).isRequired,
   withTooltip: BetterPropTypes.bool.isOptionalButNotNull,

--- a/contents/Table/types.ts
+++ b/contents/Table/types.ts
@@ -4,6 +4,7 @@ export type TableActionColumnProps = {
   Icon: any
   accent: Common.Accent
   action: (id: any) => void | Promise<void>
+  key: string
   label: string
   type: 'action'
   withTooltip?: boolean

--- a/helpers/generateKeyFromValue.ts
+++ b/helpers/generateKeyFromValue.ts
@@ -1,5 +1,0 @@
-import sha1 from 'sha1'
-
-export function generateKeyFromValue(value: any): string {
-  return sha1(JSON.stringify(value))
-}

--- a/stories/contents/Table.stories.tsx
+++ b/stories/contents/Table.stories.tsx
@@ -55,12 +55,14 @@ const COLUMNS: TableColumnProps[] = [
     action: id => window.alert(`Edit user account with id=${id}.`),
     accent: SUI.ACCENT.SECONDARY,
     Icon: Edit,
+    key: 'edit',
   },
   {
     accent: 'danger',
     // eslint-disable-next-line no-alert
     action: id => window.alert(`Delete user account with id=${id}.`),
     Icon: Trash,
+    key: 'delete',
     label: 'Delete user',
     type: 'action',
   },


### PR DESCRIPTION
BREAKING CHANGE: `key` prop is now required for all columns in Table, including action ones